### PR TITLE
Add typesafe resolver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,11 +89,6 @@
         </dependency>
         <dependency>
             <groupId>com.codacy</groupId>
-            <artifactId>codacy-api-scala_2.11</artifactId>
-            <version>1.0.2</version>
-        </dependency>
-        <dependency>
-            <groupId>com.codacy</groupId>
             <artifactId>coverage-parser_2.11</artifactId>
             <version>1.1.4</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,11 @@
          <name>Sonatype snapshots</name>
          <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
        </repository>
+       <repository>
+         <id>typesafe-releases</id>
+         <name>Typesafe releases</name>
+         <url>http://repo.typesafe.com/typesafe/releases/</url>
+       </repository>
      </repositories>
 
     <dependencies>


### PR DESCRIPTION
Should fix the error regarding netty-http-pipelining dependency

Also, removed codacy-api scala sdk from dependencies, since you should not need it.