### PR TITLE
Add support for trusting self-signed certificates of the Codacy server

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ where:
 * *coverageReportFile* is either a Jacoco or Cobertura file
 * *projectToken* is your project token
 * *apiToken* is your api token
-*
 
 **Enterprise**
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ To send coverage in the enterprise version you should:
 export CODACY_API_BASE_URL=<Codacy_instance_URL>:16006
 ```
 
+In case your on-prem codacy server has a self-signed certificate, 
+use `-Dcodacy.trustSelfSignedCerts` in the command line, 
+or configure the plugin in the `pom.xml` using:
+```xml
+<configuration>
+  <trustSelfSignedCerts>true</trustSelfSignedCerts>
+</configuration>
+``` 
+
 ## License
 
 MIT

--- a/src/main/java/com/gavinmogan/CodacyCoverageReporterMojo.java
+++ b/src/main/java/com/gavinmogan/CodacyCoverageReporterMojo.java
@@ -63,7 +63,8 @@ public class CodacyCoverageReporterMojo extends AbstractMojo
     private String language;
 
     /**
-     * your project coverage file name
+     * your project commit revision for which to upload the coverage data
+     * (default: the latest commit of the current git branch)
      */
     @Parameter( defaultValue = "${env.CI_COMMIT}", property = "commit", required = false )
     private String commit;


### PR DESCRIPTION
Mainly targeted for on-prem Codacy servers which sometimes have a self-signed SSL certificate (instead of signed by a known CA). This flag is disabled by default and can be enabled, either using command line argument `-Dcodacy.trustSelfSignedCerts`, or in the `pom.xml` in the plugin configuration by setting 
```xml
<trustSelfSignedCerts>true</trustSelfSignedCerts>
```

Without this feature, when trying to upload coverage data to Codacy server with a self-signed certificate, the build run ends with the following error:
```
[ERROR] Failed to execute goal com.gavinmogan:codacy-maven-plugin:1.0.4-SNAPSHOT:coverage (default-cli) on project commands-cli: 
Failed to upload coverage data. Reason: sun.security.validator.ValidatorException: PKIX path building failed: 
sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
```

More details:
```
[INFO] Uploading coverage data...
[ERROR] Failed to upload coverage data.
javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
    at sun.security.ssl.Alerts.getSSLException (Alerts.java:192)
    at sun.security.ssl.SSLSocketImpl.fatal (SSLSocketImpl.java:1964)
    at sun.security.ssl.Handshaker.fatalSE (Handshaker.java:328)
    at sun.security.ssl.Handshaker.fatalSE (Handshaker.java:322)
    at sun.security.ssl.ClientHandshaker.serverCertificate (ClientHandshaker.java:1614)
    at sun.security.ssl.ClientHandshaker.processMessage (ClientHandshaker.java:216)
    at sun.security.ssl.Handshaker.processLoop (Handshaker.java:1052)
    at sun.security.ssl.Handshaker.process_record (Handshaker.java:987)
    at sun.security.ssl.SSLSocketImpl.readRecord (SSLSocketImpl.java:1072)
    at sun.security.ssl.SSLSocketImpl.performInitialHandshake (SSLSocketImpl.java:1385)
    at sun.security.ssl.SSLSocketImpl.startHandshake (SSLSocketImpl.java:1413)
    at sun.security.ssl.SSLSocketImpl.startHandshake (SSLSocketImpl.java:1397)
    at org.apache.http.conn.ssl.SSLConnectionSocketFactory.createLayeredSocket (SSLConnectionSocketFactory.java:394)
    at org.apache.http.conn.ssl.SSLConnectionSocketFactory.connectSocket (SSLConnectionSocketFactory.java:353)
    at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect (DefaultHttpClientConnectionOperator.java:141)
    at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect (PoolingHttpClientConnectionManager.java:353)
    at org.apache.http.impl.execchain.MainClientExec.establishRoute (MainClientExec.java:380)
    at org.apache.http.impl.execchain.MainClientExec.execute (MainClientExec.java:236)
    at org.apache.http.impl.execchain.ProtocolExec.execute (ProtocolExec.java:184)
    at org.apache.http.impl.execchain.RetryExec.execute (RetryExec.java:88)
    at org.apache.http.impl.execchain.RedirectExec.execute (RedirectExec.java:110)
    at org.apache.http.impl.client.InternalHttpClient.doExecute (InternalHttpClient.java:184)
    at org.apache.http.impl.client.CloseableHttpClient.execute (CloseableHttpClient.java:71)
    at org.apache.http.impl.client.CloseableHttpClient.execute (CloseableHttpClient.java:220)
    at org.apache.http.impl.client.CloseableHttpClient.execute (CloseableHttpClient.java:164)
    at org.apache.http.impl.client.CloseableHttpClient.execute (CloseableHttpClient.java:139)
    at com.gavinmogan.CodacyCoverageReporterMojo.postReport (CodacyCoverageReporterMojo.java:180)
...
Caused by: sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
    at sun.security.validator.PKIXValidator.doBuild (PKIXValidator.java:397)
    at sun.security.validator.PKIXValidator.engineValidate (PKIXValidator.java:302)
    at sun.security.validator.Validator.validate (Validator.java:260)
    at sun.security.ssl.X509TrustManagerImpl.validate (X509TrustManagerImpl.java:324)
    at sun.security.ssl.X509TrustManagerImpl.checkTrusted (X509TrustManagerImpl.java:229)
    at sun.security.ssl.X509TrustManagerImpl.checkServerTrusted (X509TrustManagerImpl.java:124)
    at sun.security.ssl.ClientHandshaker.serverCertificate (ClientHandshaker.java:1596)
    at sun.security.ssl.ClientHandshaker.processMessage (ClientHandshaker.java:216)
...
Caused by: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
    at sun.security.provider.certpath.SunCertPathBuilder.build (SunCertPathBuilder.java:141)
    at sun.security.provider.certpath.SunCertPathBuilder.engineBuild (SunCertPathBuilder.java:126)
    at java.security.cert.CertPathBuilder.build (CertPathBuilder.java:280)
    at sun.security.validator.PKIXValidator.doBuild (PKIXValidator.java:392)
    at sun.security.validator.PKIXValidator.engineValidate (PKIXValidator.java:302)
    at sun.security.validator.Validator.validate (Validator.java:260)
    at sun.security.ssl.X509TrustManagerImpl.validate (X509TrustManagerImpl.java:324)
```